### PR TITLE
Add database schema and first connected frontend-backend flow

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,10 @@
+import ScheduleList from "./components/ScheduleList.jsx";
+
+export default function App() {
+  return (
+    <main>
+      <h1>Cohort Compass</h1>
+      <ScheduleList />
+    </main>
+  );
+}

--- a/client/src/components/ScheduleList.jsx
+++ b/client/src/components/ScheduleList.jsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { fetchScheduleItems } from "../api/scheduleApi.js";
+
+export default function ScheduleList() {
+  const [scheduleItems, setScheduleItems] = useState([]);
+  const [status, setStatus] = useState("loading");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  useEffect(() => {
+    async function loadScheduleItems() {
+      try {
+        const items = await fetchScheduleItems();
+
+        setScheduleItems(items);
+        setStatus("success");
+      } catch (error) {
+        setErrorMessage(error.message);
+        setStatus("error");
+      }
+    }
+
+    loadScheduleItems();
+  }, []);
+
+  if (status === "loading") {
+    return <p>Loading schedule...</p>;
+  }
+
+  if (status === "error") {
+    return <p>{errorMessage}</p>;
+  }
+
+  return (
+    <section>
+      <h2>Upcoming Schedule</h2>
+
+      <ul>
+        {scheduleItems.map((item) => (
+          <li key={item.id}>
+            <h3>{item.title}</h3>
+            <p>{item.description}</p>
+            <p>
+              {new Date(item.start_time).toLocaleString()} -{" "}
+              {new Date(item.end_time).toLocaleString()}
+            </p>
+            <p>{item.location}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App from "./App.jsx";
 
-createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById("root")).render(
   <StrictMode>
     <App />
   </StrictMode>,
-)
+);


### PR DESCRIPTION
## Summary
- Render the first connected schedule flow in React
- Add a ScheduleList component with loading, error, and success states
- Connect App.jsx to the schedule API helper so seeded schedule data appears in the browser

## Screenshot
<img width="660" height="729" alt="database-render-first" src="https://github.com/user-attachments/assets/11914329-9ac2-42ba-9bfa-6d57acd2dec2" />

## Verification
- client: npm run lint
- client: npm run test:run
- client: npm run build
- server: npm test

## Local Testing Notes
1. Start the server from `server/` with `npm run dev`
2. Start the client from `client/` with `npm run dev`
3. Open `http://localhost:5173/`
4. Confirm seeded schedule items render on the page

## Issues
Closes #3
Closes #4

Note: Backend schema/API setup was completed on main before this branch was created; this branch completes the frontend rendering portion of the first data flow.
