### PR TITLE
Complete frontend integration catch-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Cohort Compass
+
+Cohort Compass is a student hub for Techtonica participants. This README starts with the main project links so staff and reviewers can quickly find the planning materials, deployed app, GitHub project board, and repository.
+
+## Project Links
+
+- Planning document: https://docs.google.com/document/d/1yWPORO5A6SUypcOhJe4VgpmYCTEtYpDQdpOa7JSdQIo/edit?usp=sharing
+- GitHub repository: https://github.com/itspaigenli/cohort-compass
+- GitHub Project board: https://github.com/users/itspaigenli/projects/1/views/1
+- Deployed frontend: https://cohortcompass.onrender.com
+- Deployed backend: https://cohort-compass-1.onrender.com
+- Backend API base: https://cohort-compass-1.onrender.com/api

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,6 +3,17 @@ import LinksPreview from "./components/dashboard/LinksPreview.jsx";
 import RemindersPanel from "./components/dashboard/RemindersPanel.jsx";
 import SchedulePreview from "./components/dashboard/SchedulePreview.jsx";
 
+function DashboardSection({ id, className, title, children }) {
+  const headingId = `${id}-heading`;
+
+  return (
+    <section id={id} className={className} aria-labelledby={headingId}>
+      <h2 id={headingId}>{title}</h2>
+      {children}
+    </section>
+  );
+}
+
 function App() {
   return (
     <main className="app-shell">
@@ -22,37 +33,37 @@ function App() {
         <a href="#reminders">Reminders</a>
       </nav>
 
-      <section
+      <DashboardSection
         id="schedule"
         className="schedule-section"
-        aria-labelledby="schedule-heading"
+        title="Upcoming Schedule"
       >
-        <h2 id="schedule-heading">Upcoming Schedule</h2>
         <SchedulePreview />
-      </section>
+      </DashboardSection>
 
-      <section
+      <DashboardSection
         id="links"
         className="links-section"
-        aria-labelledby="links-heading"
+        title="Important Links"
       >
-        <h2 id="links-heading">Important Links</h2>
         <LinksPreview />
-      </section>
+      </DashboardSection>
 
-      <section id="faq" className="faq-section" aria-labelledby="faq-heading">
-        <h2 id="faq-heading">Debugging FAQ</h2>
+      <DashboardSection
+        id="faq"
+        className="faq-section"
+        title="Debugging FAQ"
+      >
         <FaqPreview />
-      </section>
+      </DashboardSection>
 
-      <section
+      <DashboardSection
         id="reminders"
         className="reminders-section"
-        aria-labelledby="reminders-heading"
+        title="Reminders"
       >
-        <h2 id="reminders-heading">Reminders</h2>
         <RemindersPanel />
-      </section>
+      </DashboardSection>
     </main>
   );
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -33,6 +33,17 @@ function App() {
         <a href="#reminders">Reminders</a>
       </nav>
 
+      <section className="quick-find" aria-labelledby="quick-find-heading">
+        <p className="eyebrow">Find what you need</p>
+        <h2 id="quick-find-heading">What are you looking for?</h2>
+        <div className="quick-find-links">
+          <a href="#schedule">Today&apos;s schedule</a>
+          <a href="#links">Program links</a>
+          <a href="#faq">Debugging help</a>
+          <a href="#reminders">My reminders</a>
+        </div>
+      </section>
+
       <DashboardSection
         id="schedule"
         className="schedule-section"

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -15,6 +15,13 @@ function App() {
         </p>
       </header>
 
+      <nav className="section-nav" aria-label="Main sections">
+        <a href="#schedule">Schedule</a>
+        <a href="#links">Links</a>
+        <a href="#faq">FAQ</a>
+        <a href="#reminders">Reminders</a>
+      </nav>
+
       <section
         id="schedule"
         className="schedule-section"

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -1,0 +1,73 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import App from "./App.jsx";
+
+vi.mock("./components/dashboard/SchedulePreview.jsx", () => ({
+  default: () => <p>Schedule preview test content</p>,
+}));
+
+vi.mock("./components/dashboard/LinksPreview.jsx", () => ({
+  default: () => <p>Links preview test content</p>,
+}));
+
+vi.mock("./components/dashboard/FaqPreview.jsx", () => ({
+  default: () => <p>FAQ preview test content</p>,
+}));
+
+vi.mock("./components/dashboard/RemindersPanel.jsx", () => ({
+  default: () => <p>Reminders preview test content</p>,
+}));
+
+describe("App", () => {
+  it("renders the main homepage navigation links", () => {
+    // Arrange
+    render(<App />);
+
+    const navigation = screen.getByRole("navigation", {
+      name: /main sections/i,
+    });
+
+    // Act
+    // No user action is needed because the navigation renders on page load.
+
+    // Assert
+    expect(navigation).toBeInTheDocument();
+    expect(
+      within(navigation).getByRole("link", { name: /schedule/i }),
+    ).toHaveAttribute("href", "#schedule");
+    expect(
+      within(navigation).getByRole("link", { name: /links/i }),
+    ).toHaveAttribute("href", "#links");
+    expect(
+      within(navigation).getByRole("link", { name: /faq/i }),
+    ).toHaveAttribute("href", "#faq");
+    expect(
+      within(navigation).getByRole("link", { name: /reminders/i }),
+    ).toHaveAttribute("href", "#reminders");
+  });
+
+  it("renders the quick-find homepage shortcuts", () => {
+    // Arrange
+    render(<App />);
+
+    // Act
+    // No user action is needed because the shortcuts render on page load.
+
+    // Assert
+    expect(
+      screen.getByRole("heading", { name: /what are you looking for/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /today's schedule/i }),
+    ).toHaveAttribute("href", "#schedule");
+    expect(
+      screen.getByRole("link", { name: /program links/i }),
+    ).toHaveAttribute("href", "#links");
+    expect(
+      screen.getByRole("link", { name: /debugging help/i }),
+    ).toHaveAttribute("href", "#faq");
+    expect(
+      screen.getByRole("link", { name: /my reminders/i }),
+    ).toHaveAttribute("href", "#reminders");
+  });
+});

--- a/client/src/components/dashboard/FaqPreview.test.jsx
+++ b/client/src/components/dashboard/FaqPreview.test.jsx
@@ -1,0 +1,63 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import FaqPreview from "./FaqPreview.jsx";
+import { fetchFaqEntries } from "../../services/faqApi.js";
+
+vi.mock("../../services/faqApi.js", () => ({
+  fetchFaqEntries: vi.fn(),
+}));
+
+describe("FaqPreview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders FAQ entries from the API", async () => {
+    // Arrange
+    fetchFaqEntries.mockResolvedValue([
+      {
+        id: 1,
+        question: "Why is my API request failing?",
+        answer: "Check the route, server logs, and network response.",
+        category: "Debugging",
+      },
+    ]);
+
+    // Act
+    render(<FaqPreview />);
+
+    // Assert
+    expect(screen.getByText(/loading faq/i)).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", {
+        name: /why is my api request failing/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/check the route/i)).toBeInTheDocument();
+    expect(screen.getByText(/debugging/i)).toBeInTheDocument();
+  });
+
+  it("renders an empty message when no FAQ entries are returned", async () => {
+    // Arrange
+    fetchFaqEntries.mockResolvedValue([]);
+
+    // Act
+    render(<FaqPreview />);
+
+    // Assert
+    expect(await screen.findByText(/no faq entries yet/i)).toBeInTheDocument();
+  });
+
+  it("renders an error message when the API request fails", async () => {
+    // Arrange
+    fetchFaqEntries.mockRejectedValue(new Error("FAQ request failed"));
+
+    // Act
+    render(<FaqPreview />);
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.getByText(/faq request failed/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/components/dashboard/LinksPreview.jsx
+++ b/client/src/components/dashboard/LinksPreview.jsx
@@ -44,7 +44,11 @@ export default function LinksPreview() {
             </a>
           </h3>
           <p>{link.description}</p>
-          <p>{link.category}</p>
+          {link.category ? (
+            <p>
+              <strong>Category:</strong> {link.category}
+            </p>
+          ) : null}
         </li>
       ))}
     </ul>

--- a/client/src/components/dashboard/LinksPreview.test.jsx
+++ b/client/src/components/dashboard/LinksPreview.test.jsx
@@ -1,0 +1,67 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import LinksPreview from "./LinksPreview.jsx";
+import { fetchLinks } from "../../services/linksApi.js";
+
+vi.mock("../../services/linksApi.js", () => ({
+  fetchLinks: vi.fn(),
+}));
+
+describe("LinksPreview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders important links from the API", async () => {
+    // Arrange
+    fetchLinks.mockResolvedValue([
+      {
+        id: 1,
+        title: "Techtonica",
+        url: "https://techtonica.org",
+        description: "Program information and resources.",
+        category: "Official",
+      },
+    ]);
+
+    // Act
+    render(<LinksPreview />);
+
+    // Assert
+    expect(screen.getByText(/loading links/i)).toBeInTheDocument();
+
+    const link = await screen.findByRole("link", { name: /techtonica/i });
+
+    expect(link).toHaveAttribute("href", "https://techtonica.org");
+    expect(
+      screen.getByText(/program information and resources/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/official/i)).toBeInTheDocument();
+  });
+
+  it("renders an empty message when no links are returned", async () => {
+    // Arrange
+    fetchLinks.mockResolvedValue([]);
+
+    // Act
+    render(<LinksPreview />);
+
+    // Assert
+    expect(
+      await screen.findByText(/no important links yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an error message when the API request fails", async () => {
+    // Arrange
+    fetchLinks.mockRejectedValue(new Error("Links request failed"));
+
+    // Act
+    render(<LinksPreview />);
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.getByText(/links request failed/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/components/dashboard/RemindersPanel.jsx
+++ b/client/src/components/dashboard/RemindersPanel.jsx
@@ -33,6 +33,8 @@ export default function RemindersPanel() {
   const [status, setStatus] = useState("loading");
   const [errorMessage, setErrorMessage] = useState("");
   const [actionError, setActionError] = useState("");
+  const completedCount = reminders.filter((reminder) => reminder.done).length;
+  const remainingCount = reminders.length - completedCount;
 
   useEffect(() => {
     async function loadReminders() {
@@ -132,26 +134,31 @@ export default function RemindersPanel() {
       {!reminders.length ? <p>No reminders yet.</p> : null}
 
       {reminders.length ? (
-        <ul>
-          {reminders.map((reminder) => (
-            <li key={reminder.id}>
-              <label className="reminder-item-label">
-                <input
-                  type="checkbox"
-                  checked={reminder.done}
-                  onChange={() => handleToggle(reminder)}
-                />
-                <span>{reminder.text}</span>
-              </label>
-              {formatDueDate(reminder.due_at) ? (
-                <p>Due {formatDueDate(reminder.due_at)}</p>
-              ) : null}
-              <button type="button" onClick={() => handleDelete(reminder.id)}>
-                Remove
-              </button>
-            </li>
-          ))}
-        </ul>
+        <>
+          <p>
+            {remainingCount} remaining · {completedCount} completed
+          </p>
+          <ul>
+            {reminders.map((reminder) => (
+              <li key={reminder.id}>
+                <label className="reminder-item-label">
+                  <input
+                    type="checkbox"
+                    checked={reminder.done}
+                    onChange={() => handleToggle(reminder)}
+                  />
+                  <span>{reminder.text}</span>
+                </label>
+                {formatDueDate(reminder.due_at) ? (
+                  <p>Due {formatDueDate(reminder.due_at)}</p>
+                ) : null}
+                <button type="button" onClick={() => handleDelete(reminder.id)}>
+                  Remove
+                </button>
+              </li>
+            ))}
+          </ul>
+        </>
       ) : null}
     </>
   );

--- a/client/src/components/dashboard/RemindersPanel.test.jsx
+++ b/client/src/components/dashboard/RemindersPanel.test.jsx
@@ -43,6 +43,7 @@ describe("RemindersPanel", () => {
 
     const checkboxes = await screen.findAllByRole("checkbox");
 
+    expect(screen.getByText(/1 remaining · 1 completed/i)).toBeInTheDocument();
     expect(checkboxes[0]).toHaveAccessibleName(/submit milestone summary/i);
     expect(checkboxes[0]).not.toBeChecked();
     expect(checkboxes[1]).toHaveAccessibleName(/review readme links/i);

--- a/client/src/components/dashboard/RemindersPanel.test.jsx
+++ b/client/src/components/dashboard/RemindersPanel.test.jsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import RemindersPanel from "./RemindersPanel.jsx";
+import {
+  createReminder,
+  fetchReminders,
+} from "../../services/remindersApi.js";
+
+vi.mock("../../services/remindersApi.js", () => ({
+  createReminder: vi.fn(),
+  deleteReminder: vi.fn(),
+  fetchReminders: vi.fn(),
+  updateReminder: vi.fn(),
+}));
+
+describe("RemindersPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders incomplete reminders before completed reminders", async () => {
+    // Arrange
+    fetchReminders.mockResolvedValue([
+      {
+        id: 1,
+        text: "Review README links",
+        done: true,
+        due_at: null,
+      },
+      {
+        id: 2,
+        text: "Submit milestone summary",
+        done: false,
+        due_at: null,
+      },
+    ]);
+
+    // Act
+    render(<RemindersPanel />);
+
+    // Assert
+    expect(screen.getByText(/loading reminders/i)).toBeInTheDocument();
+
+    const checkboxes = await screen.findAllByRole("checkbox");
+
+    expect(checkboxes[0]).toHaveAccessibleName(/submit milestone summary/i);
+    expect(checkboxes[0]).not.toBeChecked();
+    expect(checkboxes[1]).toHaveAccessibleName(/review readme links/i);
+    expect(checkboxes[1]).toBeChecked();
+  });
+
+  it("adds a new reminder from the form", async () => {
+    // Arrange
+    fetchReminders.mockResolvedValue([]);
+    createReminder.mockResolvedValue({
+      id: 3,
+      text: "Update project notes",
+      done: false,
+      due_at: null,
+    });
+
+    // Act
+    render(<RemindersPanel />);
+
+    const reminderInput = await screen.findByLabelText(/add reminder/i);
+    fireEvent.change(reminderInput, {
+      target: { value: "Update project notes" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add/i }));
+
+    // Assert
+    expect(createReminder).toHaveBeenCalledWith({
+      text: "Update project notes",
+    });
+    expect(
+      await screen.findByLabelText(/update project notes/i),
+    ).toBeInTheDocument();
+    expect(reminderInput).toHaveValue("");
+  });
+});

--- a/client/src/components/dashboard/SchedulePreview.jsx
+++ b/client/src/components/dashboard/SchedulePreview.jsx
@@ -48,11 +48,6 @@ export default function SchedulePreview() {
               <strong>Where:</strong> {item.location}
             </p>
           ) : null}
-          {item.meeting_url ? (
-            <a href={item.meeting_url} target="_blank" rel="noreferrer">
-              Open meeting
-            </a>
-          ) : null}
         </li>
       ))}
     </ul>

--- a/client/src/components/dashboard/SchedulePreview.jsx
+++ b/client/src/components/dashboard/SchedulePreview.jsx
@@ -40,8 +40,14 @@ export default function SchedulePreview() {
         <li key={item.id}>
           <h3>{item.title}</h3>
           <p>{item.description}</p>
-          <p>{item.date_and_duration_string}</p>
-          <p>{item.location}</p>
+          <p>
+            <strong>When:</strong> {item.date_and_duration_string}
+          </p>
+          {item.location ? (
+            <p>
+              <strong>Where:</strong> {item.location}
+            </p>
+          ) : null}
         </li>
       ))}
     </ul>

--- a/client/src/components/dashboard/SchedulePreview.jsx
+++ b/client/src/components/dashboard/SchedulePreview.jsx
@@ -48,6 +48,11 @@ export default function SchedulePreview() {
               <strong>Where:</strong> {item.location}
             </p>
           ) : null}
+          {item.meeting_url ? (
+            <a href={item.meeting_url} target="_blank" rel="noreferrer">
+              Open meeting
+            </a>
+          ) : null}
         </li>
       ))}
     </ul>

--- a/client/src/components/dashboard/SchedulePreview.test.jsx
+++ b/client/src/components/dashboard/SchedulePreview.test.jsx
@@ -33,7 +33,9 @@ describe("SchedulePreview", () => {
     expect(
       screen.getByText(/practice interview questions/i),
     ).toBeInTheDocument();
+    expect(screen.getByText(/when:/i)).toBeInTheDocument();
     expect(screen.getByText(/may 7, 10:00 am/i)).toBeInTheDocument();
+    expect(screen.getByText(/where:/i)).toBeInTheDocument();
     expect(screen.getByText(/zoom/i)).toBeInTheDocument();
   });
 

--- a/client/src/components/dashboard/SchedulePreview.test.jsx
+++ b/client/src/components/dashboard/SchedulePreview.test.jsx
@@ -21,6 +21,7 @@ describe("SchedulePreview", () => {
         description: "Practice interview questions with the cohort.",
         date_and_duration_string: "May 7, 10:00 AM - May 7, 11:00 AM",
         location: "Zoom",
+        meeting_url: "https://example.com/meeting",
       },
     ]);
 
@@ -37,6 +38,10 @@ describe("SchedulePreview", () => {
     expect(screen.getByText(/may 7, 10:00 am/i)).toBeInTheDocument();
     expect(screen.getByText(/where:/i)).toBeInTheDocument();
     expect(screen.getByText(/zoom/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /open meeting/i })).toHaveAttribute(
+      "href",
+      "https://example.com/meeting",
+    );
   });
 
   it("renders an empty message when no schedule items are returned", async () => {

--- a/client/src/components/dashboard/SchedulePreview.test.jsx
+++ b/client/src/components/dashboard/SchedulePreview.test.jsx
@@ -21,7 +21,6 @@ describe("SchedulePreview", () => {
         description: "Practice interview questions with the cohort.",
         date_and_duration_string: "May 7, 10:00 AM - May 7, 11:00 AM",
         location: "Zoom",
-        meeting_url: "https://example.com/meeting",
       },
     ]);
 
@@ -38,10 +37,6 @@ describe("SchedulePreview", () => {
     expect(screen.getByText(/may 7, 10:00 am/i)).toBeInTheDocument();
     expect(screen.getByText(/where:/i)).toBeInTheDocument();
     expect(screen.getByText(/zoom/i)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /open meeting/i })).toHaveAttribute(
-      "href",
-      "https://example.com/meeting",
-    );
   });
 
   it("renders an empty message when no schedule items are returned", async () => {

--- a/client/src/components/dashboard/SchedulePreview.test.jsx
+++ b/client/src/components/dashboard/SchedulePreview.test.jsx
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SchedulePreview from "./SchedulePreview.jsx";
+import { fetchScheduleItems } from "../../services/scheduleApi.js";
+
+vi.mock("../../services/scheduleApi.js", () => ({
+  fetchScheduleItems: vi.fn(),
+}));
+
+describe("SchedulePreview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders schedule items from the API", async () => {
+    // Arrange
+    fetchScheduleItems.mockResolvedValue([
+      {
+        id: 1,
+        title: "Career workshop",
+        description: "Practice interview questions with the cohort.",
+        date_and_duration_string: "May 7, 10:00 AM - May 7, 11:00 AM",
+        location: "Zoom",
+      },
+    ]);
+
+    // Act
+    render(<SchedulePreview />);
+
+    // Assert
+    expect(screen.getByText(/loading schedule/i)).toBeInTheDocument();
+    expect(await screen.findByText(/career workshop/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/practice interview questions/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/may 7, 10:00 am/i)).toBeInTheDocument();
+    expect(screen.getByText(/zoom/i)).toBeInTheDocument();
+  });
+
+  it("renders an empty message when no schedule items are returned", async () => {
+    // Arrange
+    fetchScheduleItems.mockResolvedValue([]);
+
+    // Act
+    render(<SchedulePreview />);
+
+    // Assert
+    expect(
+      await screen.findByText(/no upcoming schedule items yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an error message when the API request fails", async () => {
+    // Arrange
+    fetchScheduleItems.mockRejectedValue(new Error("Schedule request failed"));
+
+    // Act
+    render(<SchedulePreview />);
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.getByText(/schedule request failed/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -71,6 +71,30 @@ select {
   line-height: 1.6;
 }
 
+.section-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 0 0 1.5rem;
+}
+
+.section-nav a {
+  border: 1px solid rgba(0, 147, 181, 0.22);
+  border-radius: 8px;
+  padding: 0.55rem 0.85rem;
+  color: #05556d;
+  background: rgba(255, 255, 255, 0.76);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.section-nav a:hover,
+.section-nav a:focus {
+  border-color: rgba(252, 118, 37, 0.5);
+  color: #17313a;
+  outline: none;
+}
+
 .schedule-section,
 .links-section,
 .faq-section,
@@ -192,6 +216,15 @@ select {
 
   .hero {
     padding: 2rem 0 1rem;
+  }
+
+  .section-nav {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .section-nav a {
+    text-align: center;
   }
 
   .schedule-section,

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -95,6 +95,47 @@ select {
   outline: none;
 }
 
+.quick-find {
+  display: grid;
+  gap: 0.8rem;
+  margin-top: 1.5rem;
+  padding: 1.25rem;
+  border: 1px solid rgba(0, 147, 181, 0.18);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.quick-find h2 {
+  margin: 0;
+  color: #05556d;
+  font-size: clamp(1.45rem, 3vw, 2rem);
+}
+
+.quick-find-links {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.quick-find-links a {
+  border: 1px solid rgba(0, 147, 181, 0.14);
+  border-left: 4px solid #fc7625;
+  border-radius: 8px;
+  padding: 0.85rem;
+  color: #17313a;
+  background: #ffffff;
+  font-weight: 700;
+  line-height: 1.4;
+  text-decoration: none;
+}
+
+.quick-find-links a:hover,
+.quick-find-links a:focus {
+  border-color: rgba(252, 118, 37, 0.5);
+  color: #05556d;
+  outline: none;
+}
+
 .schedule-section,
 .links-section,
 .faq-section,
@@ -227,11 +268,16 @@ select {
     text-align: center;
   }
 
+  .quick-find,
   .schedule-section,
   .links-section,
   .faq-section,
   .reminders-section {
     padding: 1rem;
+  }
+
+  .quick-find-links {
+    grid-template-columns: 1fr;
   }
 
   .reminders-form-row {


### PR DESCRIPTION
## Summary
- Add homepage section navigation, reusable dashboard section structure, and quick-find shortcuts
- Improve student-facing schedule, links, and reminder preview details while keeping backend data as the source of truth
- Add React Testing Library coverage for App, SchedulePreview, RemindersPanel, LinksPreview, and FaqPreview
- Add staff-facing project links to the README for easier review access

## Screenshot
<img width="1101" height="976" alt="Screenshot 2026-05-07 at 18 58 44" src="https://github.com/user-attachments/assets/c6b10b6e-7abf-482e-8658-96900eb0d39e" />



## Verification
- client: `npm run test:run`
- client: `npm run build`
- server: `npm run test`
- deployed frontend: `curl https://cohortcompass.onrender.com` returned 200
- deployed API: `/api/schedule`, `/api/links`, `/api/faq`, and `/api/reminders` returned 200
- local frontend: `curl http://localhost:5173` returned 200
- local API: `curl http://localhost:3000/api/schedule` returned 200

## Local Testing Notes
1. Start the server from `server/` with `npm run dev`
2. Start the client from `client/` with `npm run dev`
3. Open `http://localhost:5173/`
4. Confirm the homepage navigation jumps to schedule, links, FAQ, and reminders
5. Confirm schedule, links, FAQ, and reminders render backend-connected data
6. Confirm the reminder list can add a reminder and show remaining/completed counts

## Issues
Related #11
Related #12
Related #28
